### PR TITLE
Add unified project milestones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 .cache/
+create-admin
+soon-cms

--- a/cmd/soon-cms/service_test.go
+++ b/cmd/soon-cms/service_test.go
@@ -16,6 +16,8 @@ func TestLatestMigrationVersion(t *testing.T) {
 		"0002_add_links.down.sql",
 		"0003_add_roadmap.up.sql",
 		"0003_add_roadmap.down.sql",
+		"0005_unify_project_milestones.up.sql",
+		"0005_unify_project_milestones.down.sql",
 	}
 	for _, f := range files {
 		if err := os.WriteFile(filepath.Join(dir, f), []byte("-- test"), 0644); err != nil {
@@ -27,8 +29,8 @@ func TestLatestMigrationVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if version != 3 {
-		t.Errorf("expected version 3, got %d", version)
+	if version != 5 {
+		t.Errorf("expected version 5, got %d", version)
 	}
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -59,16 +59,11 @@ func (s *Service) StartHTTP(errChan chan error) {
 	mux.HandleFunc("POST /service/{service}/links", a.RequireAuth(c.CreateLinkHandler))
 	mux.HandleFunc("DELETE /service/{service}/links/{id}", a.RequireAuth(c.DeleteLinkHandler))
 
-	// Protected write endpoints - roadmap
-	mux.HandleFunc("POST /service/{service}/roadmap", a.RequireAuth(c.CreateRoadmapHandler))
-	mux.HandleFunc("PUT /service/{service}/roadmap/{id}", a.RequireAuth(c.UpdateRoadmapHandler))
-	mux.HandleFunc("DELETE /service/{service}/roadmap/{id}", a.RequireAuth(c.DeleteRoadmapHandler))
-
-	// Protected write endpoints - launch tasks
-	mux.HandleFunc("GET /service/{service}/tasks", c.ListTasksHandler)
-	mux.HandleFunc("POST /service/{service}/tasks", a.RequireAuth(c.CreateTaskHandler))
-	mux.HandleFunc("PUT /service/{service}/tasks/{id}", a.RequireAuth(c.UpdateTaskHandler))
-	mux.HandleFunc("DELETE /service/{service}/tasks/{id}", a.RequireAuth(c.DeleteTaskHandler))
+	// Milestones
+	mux.HandleFunc("GET /service/{service}/milestones", c.ListMilestonesHandler)
+	mux.HandleFunc("POST /service/{service}/milestones", a.RequireAuth(c.CreateMilestoneHandler))
+	mux.HandleFunc("PUT /service/{service}/milestones/{id}", a.RequireAuth(c.UpdateMilestoneHandler))
+	mux.HandleFunc("DELETE /service/{service}/milestones/{id}", a.RequireAuth(c.DeleteMilestoneHandler))
 
 	mw := middleware.NewMiddleware()
 	mw.AddMiddleware(middleware.SetupLogger(middleware.Error).Logger)

--- a/internal/soon-cms/cms.go
+++ b/internal/soon-cms/cms.go
@@ -18,20 +18,20 @@ type CMS struct {
 }
 
 type Service struct {
-	ID          int            `json:"-"`
-	Name        string         `json:"name"`
-	SearchName  string         `json:"searchName"`
-	Description string         `json:"description"`
-	URL         string         `json:"url"`
-	LaunchDate  LaunchDate     `json:"launchDate"`
-	Progress    int            `json:"progress"`
-	Progress2   float32        `json:"progress2"`
-	Icon        string         `json:"icon"`
-	FullDesc    string         `json:"fullDesc"`
-	Uptime      string         `json:"uptime"`
-	Launched    bool           `json:"launched"`
-	Links       []ProjectLink  `json:"links,omitempty"`
-	Roadmap     []RoadmapItem  `json:"roadmap,omitempty"`
+	ID          int           `json:"-"`
+	Name        string        `json:"name"`
+	SearchName  string        `json:"searchName"`
+	Description string        `json:"description"`
+	URL         string        `json:"url"`
+	LaunchDate  LaunchDate    `json:"launchDate"`
+	Progress    int           `json:"progress"`
+	Progress2   float32       `json:"progress2"`
+	Icon        string        `json:"icon"`
+	FullDesc    string        `json:"fullDesc"`
+	Uptime      string        `json:"uptime"`
+	Launched    bool          `json:"launched"`
+	Links       []ProjectLink `json:"links,omitempty"`
+	Milestones  []Milestone   `json:"milestones,omitempty"`
 }
 
 type LaunchDate struct {
@@ -47,19 +47,16 @@ type ProjectLink struct {
 	Label    string `json:"label,omitempty"`
 }
 
-type RoadmapItem struct {
-	ID          int     `json:"id,omitempty"`
-	Name        string  `json:"name"`
-	TargetDate  *string `json:"targetDate,omitempty"`
-	ReleaseDate *string `json:"releaseDate,omitempty"`
-	Completed   bool    `json:"completed"`
-	SortOrder   int     `json:"sortOrder"`
-}
-
-type LaunchTask struct {
-	ID        int  `json:"id,omitempty"`
-	ServiceID int  `json:"serviceId"`
-	Completed bool `json:"completed"`
+type Milestone struct {
+	ID            int     `json:"id,omitempty"`
+	ServiceID     int     `json:"serviceId,omitempty"`
+	Title         string  `json:"title"`
+	Description   string  `json:"description,omitempty"`
+	Category      string  `json:"category"`
+	Status        string  `json:"status"`
+	TargetDate    *string `json:"targetDate,omitempty"`
+	CompletedDate *string `json:"completedDate,omitempty"`
+	SortOrder     int     `json:"sortOrder"`
 }
 
 type CreateServiceRequest struct {
@@ -78,19 +75,24 @@ type CreateLinkRequest struct {
 	Label    string `json:"label"`
 }
 
-type CreateRoadmapRequest struct {
-	Name       string  `json:"name"`
-	TargetDate *string `json:"targetDate"`
-	Completed  bool    `json:"completed"`
-	SortOrder  int     `json:"sortOrder"`
+type CreateMilestoneRequest struct {
+	Title         string  `json:"title"`
+	Description   string  `json:"description"`
+	Category      string  `json:"category"`
+	Status        string  `json:"status"`
+	TargetDate    *string `json:"targetDate"`
+	CompletedDate *string `json:"completedDate"`
+	SortOrder     int     `json:"sortOrder"`
 }
 
-type UpdateRoadmapRequest struct {
-	Name        *string `json:"name,omitempty"`
-	TargetDate  *string `json:"targetDate,omitempty"`
-	ReleaseDate *string `json:"releaseDate,omitempty"`
-	Completed   *bool   `json:"completed,omitempty"`
-	SortOrder   *int    `json:"sortOrder,omitempty"`
+type UpdateMilestoneRequest struct {
+	Title         *string `json:"title,omitempty"`
+	Description   *string `json:"description,omitempty"`
+	Category      *string `json:"category,omitempty"`
+	Status        *string `json:"status,omitempty"`
+	TargetDate    *string `json:"targetDate,omitempty"`
+	CompletedDate *string `json:"completedDate,omitempty"`
+	SortOrder     *int    `json:"sortOrder,omitempty"`
 }
 
 func NewCMS(config *ConfigBuilder.Config, flags *flagsService.Client, errChan chan error) *CMS {
@@ -100,6 +102,27 @@ func NewCMS(config *ConfigBuilder.Config, flags *flagsService.Client, errChan ch
 		CTX:          context.Background(),
 		ErrorChannel: errChan,
 	}
+}
+
+func calculateProgressFromStatuses(statuses []string) float32 {
+	totalRows := 0
+	completedRows := 0
+
+	for _, status := range statuses {
+		if status == "cancelled" {
+			continue
+		}
+		totalRows++
+		if status == "completed" {
+			completedRows++
+		}
+	}
+
+	if totalRows == 0 {
+		return 0
+	}
+
+	return (float32(completedRows) / float32(totalRows)) * 100
 }
 
 func (c CMS) getServices() ([]Service, error) {
@@ -197,11 +220,11 @@ func (c CMS) getService(name string) (Service, error) {
 	}
 	service.Links = links
 
-	roadmap, err := c.getServiceRoadmap(service.ID)
+	milestones, err := c.getServiceMilestones(service.ID)
 	if err != nil {
 		return service, logs.Error(err)
 	}
-	service.Roadmap = roadmap
+	service.Milestones = milestones
 
 	return service, nil
 }
@@ -216,29 +239,21 @@ func (c CMS) getServiceProgress(id int) (float32, error) {
 			c.ErrorChannel <- logs.Error(err)
 		}
 	}()
-	rows, err := db.Query(c.CTX, "SELECT completed FROM launch_task WHERE service_id = $1", id)
+	rows, err := db.Query(c.CTX, "SELECT status FROM project_milestones WHERE service_id = $1", id)
 	if err != nil {
 		return 0, logs.Error(err)
 	}
-	totalRows := 0
-	completedRows := 0
-
+	statuses := make([]string, 0)
 	defer rows.Close()
 	for rows.Next() {
-		var completed bool
-		if err := rows.Scan(&completed); err != nil {
+		var status string
+		if err := rows.Scan(&status); err != nil {
 			return 0, logs.Error(err)
 		}
-		totalRows++
-		if completed {
-			completedRows++
-		}
-	}
-	if totalRows == 0 {
-		return 0, nil
+		statuses = append(statuses, status)
 	}
 
-	return (float32(completedRows) / float32(totalRows)) * 100, nil
+	return calculateProgressFromStatuses(statuses), nil
 }
 
 func (c CMS) getServiceLinks(serviceID int) ([]ProjectLink, error) {
@@ -270,7 +285,7 @@ func (c CMS) getServiceLinks(serviceID int) ([]ProjectLink, error) {
 	return links, nil
 }
 
-func (c CMS) getServiceRoadmap(serviceID int) ([]RoadmapItem, error) {
+func (c CMS) getServiceMilestones(serviceID int) ([]Milestone, error) {
 	db, err := c.Config.Database.GetPGXClient(c.CTX)
 	if err != nil {
 		return nil, logs.Error(err)
@@ -281,22 +296,25 @@ func (c CMS) getServiceRoadmap(serviceID int) ([]RoadmapItem, error) {
 		}
 	}()
 
-	rows, err := db.Query(c.CTX, "SELECT id, name, target_date::text, release_date::text, completed, sort_order FROM project_roadmap WHERE service_id = $1 ORDER BY sort_order", serviceID)
+	rows, err := db.Query(c.CTX, `SELECT id, service_id, title, COALESCE(description, ''), category, status, target_date::text, completed_date::text, sort_order
+		FROM project_milestones
+		WHERE service_id = $1
+		ORDER BY sort_order, id`, serviceID)
 	if err != nil {
 		return nil, logs.Error(err)
 	}
 	defer rows.Close()
 
-	var roadmap []RoadmapItem
+	var milestones []Milestone
 	for rows.Next() {
-		var item RoadmapItem
-		if err := rows.Scan(&item.ID, &item.Name, &item.TargetDate, &item.ReleaseDate, &item.Completed, &item.SortOrder); err != nil {
+		var item Milestone
+		if err := rows.Scan(&item.ID, &item.ServiceID, &item.Title, &item.Description, &item.Category, &item.Status, &item.TargetDate, &item.CompletedDate, &item.SortOrder); err != nil {
 			return nil, logs.Error(err)
 		}
-		roadmap = append(roadmap, item)
+		milestones = append(milestones, item)
 	}
 
-	return roadmap, nil
+	return milestones, nil
 }
 
 // Write operations
@@ -417,78 +435,7 @@ func (c CMS) deleteLink(linkID int) error {
 	return nil
 }
 
-func (c CMS) createRoadmapItem(serviceName string, req CreateRoadmapRequest) (RoadmapItem, error) {
-	db, err := c.Config.Database.GetPGXClient(c.CTX)
-	if err != nil {
-		return RoadmapItem{}, logs.Error(err)
-	}
-	defer func() {
-		if err := db.Close(c.CTX); err != nil {
-			c.ErrorChannel <- logs.Error(err)
-		}
-	}()
-
-	var item RoadmapItem
-	err = db.QueryRow(c.CTX,
-		`INSERT INTO project_roadmap (service_id, name, target_date, completed, sort_order)
-		 SELECT id, $2, $3::date, $4, $5 FROM services WHERE search_name = $1
-		 RETURNING id, name, target_date::text, release_date::text, completed, sort_order`,
-		serviceName, req.Name, req.TargetDate, req.Completed, req.SortOrder,
-	).Scan(&item.ID, &item.Name, &item.TargetDate, &item.ReleaseDate, &item.Completed, &item.SortOrder)
-	if err != nil {
-		return RoadmapItem{}, logs.Error(err)
-	}
-	return item, nil
-}
-
-func (c CMS) updateRoadmapItem(itemID int, req UpdateRoadmapRequest) (RoadmapItem, error) {
-	db, err := c.Config.Database.GetPGXClient(c.CTX)
-	if err != nil {
-		return RoadmapItem{}, logs.Error(err)
-	}
-	defer func() {
-		if err := db.Close(c.CTX); err != nil {
-			c.ErrorChannel <- logs.Error(err)
-		}
-	}()
-
-	var item RoadmapItem
-	err = db.QueryRow(c.CTX,
-		`UPDATE project_roadmap SET
-		 name = COALESCE($2, name),
-		 target_date = COALESCE($3::date, target_date),
-		 release_date = COALESCE($4::date, release_date),
-		 completed = COALESCE($5, completed),
-		 sort_order = COALESCE($6, sort_order)
-		 WHERE id = $1
-		 RETURNING id, name, target_date::text, release_date::text, completed, sort_order`,
-		itemID, req.Name, req.TargetDate, req.ReleaseDate, req.Completed, req.SortOrder,
-	).Scan(&item.ID, &item.Name, &item.TargetDate, &item.ReleaseDate, &item.Completed, &item.SortOrder)
-	if err != nil {
-		return RoadmapItem{}, logs.Error(err)
-	}
-	return item, nil
-}
-
-func (c CMS) deleteRoadmapItem(itemID int) error {
-	db, err := c.Config.Database.GetPGXClient(c.CTX)
-	if err != nil {
-		return logs.Error(err)
-	}
-	defer func() {
-		if err := db.Close(c.CTX); err != nil {
-			c.ErrorChannel <- logs.Error(err)
-		}
-	}()
-
-	_, err = db.Exec(c.CTX, "DELETE FROM project_roadmap WHERE id = $1", itemID)
-	if err != nil {
-		return logs.Error(err)
-	}
-	return nil
-}
-
-func (c CMS) getLaunchTasks(serviceName string) ([]LaunchTask, error) {
+func (c CMS) getMilestones(serviceName string) ([]Milestone, error) {
 	db, err := c.Config.Database.GetPGXClient(c.CTX)
 	if err != nil {
 		return nil, logs.Error(err)
@@ -499,30 +446,31 @@ func (c CMS) getLaunchTasks(serviceName string) ([]LaunchTask, error) {
 		}
 	}()
 
-	rows, err := db.Query(c.CTX,
-		`SELECT lt.launch_task_id, lt.service_id, lt.completed FROM launch_task lt
-		 JOIN services s ON s.id = lt.service_id
-		 WHERE s.search_name = $1`, serviceName)
+	rows, err := db.Query(c.CTX, `SELECT pm.id, pm.service_id, pm.title, COALESCE(pm.description, ''), pm.category, pm.status, pm.target_date::text, pm.completed_date::text, pm.sort_order
+		FROM project_milestones pm
+		JOIN services s ON s.id = pm.service_id
+		WHERE s.search_name = $1
+		ORDER BY pm.sort_order, pm.id`, serviceName)
 	if err != nil {
 		return nil, logs.Error(err)
 	}
 	defer rows.Close()
 
-	var tasks []LaunchTask
+	var milestones []Milestone
 	for rows.Next() {
-		var t LaunchTask
-		if err := rows.Scan(&t.ID, &t.ServiceID, &t.Completed); err != nil {
+		var item Milestone
+		if err := rows.Scan(&item.ID, &item.ServiceID, &item.Title, &item.Description, &item.Category, &item.Status, &item.TargetDate, &item.CompletedDate, &item.SortOrder); err != nil {
 			return nil, logs.Error(err)
 		}
-		tasks = append(tasks, t)
+		milestones = append(milestones, item)
 	}
-	return tasks, nil
+	return milestones, nil
 }
 
-func (c CMS) createLaunchTask(serviceName string, completed bool) (LaunchTask, error) {
+func (c CMS) createMilestone(serviceName string, req CreateMilestoneRequest) (Milestone, error) {
 	db, err := c.Config.Database.GetPGXClient(c.CTX)
 	if err != nil {
-		return LaunchTask{}, logs.Error(err)
+		return Milestone{}, logs.Error(err)
 	}
 	defer func() {
 		if err := db.Close(c.CTX); err != nil {
@@ -530,23 +478,23 @@ func (c CMS) createLaunchTask(serviceName string, completed bool) (LaunchTask, e
 		}
 	}()
 
-	var t LaunchTask
+	var item Milestone
 	err = db.QueryRow(c.CTX,
-		`INSERT INTO launch_task (service_id, completed)
-		 SELECT id, $2 FROM services WHERE search_name = $1
-		 RETURNING launch_task_id, service_id, completed`,
-		serviceName, completed,
-	).Scan(&t.ID, &t.ServiceID, &t.Completed)
+		`INSERT INTO project_milestones (service_id, title, description, category, status, target_date, completed_date, sort_order)
+		 SELECT id, $2, NULLIF($3, ''), $4, $5, $6::date, $7::date, $8 FROM services WHERE search_name = $1
+		 RETURNING id, service_id, title, COALESCE(description, ''), category, status, target_date::text, completed_date::text, sort_order`,
+		serviceName, req.Title, req.Description, req.Category, req.Status, req.TargetDate, req.CompletedDate, req.SortOrder,
+	).Scan(&item.ID, &item.ServiceID, &item.Title, &item.Description, &item.Category, &item.Status, &item.TargetDate, &item.CompletedDate, &item.SortOrder)
 	if err != nil {
-		return LaunchTask{}, logs.Error(err)
+		return Milestone{}, logs.Error(err)
 	}
-	return t, nil
+	return item, nil
 }
 
-func (c CMS) updateLaunchTask(taskID int, completed bool) (LaunchTask, error) {
+func (c CMS) updateMilestone(itemID int, req UpdateMilestoneRequest) (Milestone, error) {
 	db, err := c.Config.Database.GetPGXClient(c.CTX)
 	if err != nil {
-		return LaunchTask{}, logs.Error(err)
+		return Milestone{}, logs.Error(err)
 	}
 	defer func() {
 		if err := db.Close(c.CTX); err != nil {
@@ -554,19 +502,28 @@ func (c CMS) updateLaunchTask(taskID int, completed bool) (LaunchTask, error) {
 		}
 	}()
 
-	var t LaunchTask
+	var item Milestone
 	err = db.QueryRow(c.CTX,
-		`UPDATE launch_task SET completed = $2 WHERE launch_task_id = $1
-		 RETURNING launch_task_id, service_id, completed`,
-		taskID, completed,
-	).Scan(&t.ID, &t.ServiceID, &t.Completed)
+		`UPDATE project_milestones SET
+		 title = COALESCE($2, title),
+		 description = COALESCE(NULLIF($3, ''), description),
+		 category = COALESCE($4, category),
+		 status = COALESCE($5, status),
+		 target_date = COALESCE($6::date, target_date),
+		 completed_date = COALESCE($7::date, completed_date),
+		 sort_order = COALESCE($8, sort_order),
+		 updated_at = NOW()
+		 WHERE id = $1
+		 RETURNING id, service_id, title, COALESCE(description, ''), category, status, target_date::text, completed_date::text, sort_order`,
+		itemID, req.Title, req.Description, req.Category, req.Status, req.TargetDate, req.CompletedDate, req.SortOrder,
+	).Scan(&item.ID, &item.ServiceID, &item.Title, &item.Description, &item.Category, &item.Status, &item.TargetDate, &item.CompletedDate, &item.SortOrder)
 	if err != nil {
-		return LaunchTask{}, logs.Error(err)
+		return Milestone{}, logs.Error(err)
 	}
-	return t, nil
+	return item, nil
 }
 
-func (c CMS) deleteLaunchTask(taskID int) error {
+func (c CMS) deleteMilestone(itemID int) error {
 	db, err := c.Config.Database.GetPGXClient(c.CTX)
 	if err != nil {
 		return logs.Error(err)
@@ -577,7 +534,7 @@ func (c CMS) deleteLaunchTask(taskID int) error {
 		}
 	}()
 
-	_, err = db.Exec(c.CTX, "DELETE FROM launch_task WHERE launch_task_id = $1", taskID)
+	_, err = db.Exec(c.CTX, "DELETE FROM project_milestones WHERE id = $1", itemID)
 	if err != nil {
 		return logs.Error(err)
 	}

--- a/internal/soon-cms/cms_test.go
+++ b/internal/soon-cms/cms_test.go
@@ -33,6 +33,27 @@ func TestGetProgressColor(t *testing.T) {
 	}
 }
 
+func TestCalculateProgressFromStatuses(t *testing.T) {
+	tests := []struct {
+		name     string
+		statuses []string
+		expected float32
+	}{
+		{"no milestones", nil, 0},
+		{"all completed", []string{"completed", "completed"}, 100},
+		{"ignores cancelled", []string{"completed", "cancelled", "planned"}, 50},
+		{"in progress not complete", []string{"in_progress", "planned"}, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculateProgressFromStatuses(tt.statuses)
+			if result != tt.expected {
+				t.Errorf("expected %f, got %f", tt.expected, result)
+			}
+		})
+	}
+}
 func TestProjectLinkType(t *testing.T) {
 	link := ProjectLink{
 		LinkType: "dashboard",
@@ -48,20 +69,21 @@ func TestProjectLinkType(t *testing.T) {
 	}
 }
 
-func TestRoadmapItemType(t *testing.T) {
+func TestMilestoneType(t *testing.T) {
 	target := "2026-06-01"
-	item := RoadmapItem{
-		Name:       "Beta release",
+	item := Milestone{
+		Title:      "Beta release",
+		Category:   "release",
+		Status:     "planned",
 		TargetDate: &target,
-		Completed:  false,
 		SortOrder:  1,
 	}
 
-	if item.Name != "Beta release" {
-		t.Errorf("expected 'Beta release', got '%s'", item.Name)
+	if item.Title != "Beta release" {
+		t.Errorf("expected 'Beta release', got '%s'", item.Title)
 	}
-	if item.Completed {
-		t.Error("expected not completed")
+	if item.Status != "planned" {
+		t.Errorf("expected planned, got '%s'", item.Status)
 	}
 	if *item.TargetDate != "2026-06-01" {
 		t.Errorf("expected '2026-06-01', got '%s'", *item.TargetDate)
@@ -83,23 +105,23 @@ func TestServiceStruct(t *testing.T) {
 			{LinkType: "dashboard", URL: "https://dashboard.flags.gg", Label: "Dashboard"},
 			{LinkType: "docs", URL: "https://docs.flags.gg", Label: "Docs"},
 		},
-		Roadmap: []RoadmapItem{
-			{Name: "Alpha", Completed: true, SortOrder: 0},
-			{Name: "Beta", Completed: false, SortOrder: 1},
+		Milestones: []Milestone{
+			{Title: "Alpha", Category: "feature", Status: "completed", SortOrder: 0},
+			{Title: "Beta", Category: "feature", Status: "planned", SortOrder: 1},
 		},
 	}
 
 	if len(svc.Links) != 3 {
 		t.Errorf("expected 3 links, got %d", len(svc.Links))
 	}
-	if len(svc.Roadmap) != 2 {
-		t.Errorf("expected 2 roadmap items, got %d", len(svc.Roadmap))
+	if len(svc.Milestones) != 2 {
+		t.Errorf("expected 2 milestones, got %d", len(svc.Milestones))
 	}
 	if svc.Links[1].LinkType != "dashboard" {
 		t.Errorf("expected 'dashboard', got '%s'", svc.Links[1].LinkType)
 	}
-	if !svc.Roadmap[0].Completed {
-		t.Error("expected first roadmap item to be completed")
+	if svc.Milestones[0].Status != "completed" {
+		t.Error("expected first milestone to be completed")
 	}
 }
 
@@ -107,20 +129,6 @@ func TestLaunchDate(t *testing.T) {
 	ld := LaunchDate{Year: 2026, Month: 3, Day: 20}
 	if ld.Year != 2026 || ld.Month != 3 || ld.Day != 20 {
 		t.Errorf("unexpected launch date: %+v", ld)
-	}
-}
-
-func TestLaunchTaskType(t *testing.T) {
-	task := LaunchTask{
-		ID:        1,
-		ServiceID: 5,
-		Completed: false,
-	}
-	if task.ID != 1 {
-		t.Errorf("expected ID 1, got %d", task.ID)
-	}
-	if task.Completed {
-		t.Error("expected not completed")
 	}
 }
 
@@ -155,19 +163,19 @@ func TestCreateLinkRequest(t *testing.T) {
 	}
 }
 
-func TestUpdateRoadmapRequest(t *testing.T) {
-	completed := true
-	name := "Updated name"
-	req := UpdateRoadmapRequest{
-		Name:      &name,
-		Completed: &completed,
+func TestUpdateMilestoneRequest(t *testing.T) {
+	status := "completed"
+	title := "Updated name"
+	req := UpdateMilestoneRequest{
+		Title:  &title,
+		Status: &status,
 	}
 
-	if *req.Completed != true {
-		t.Error("expected completed to be true")
+	if *req.Status != "completed" {
+		t.Error("expected status to be completed")
 	}
-	if *req.Name != "Updated name" {
-		t.Errorf("expected 'Updated name', got '%s'", *req.Name)
+	if *req.Title != "Updated name" {
+		t.Errorf("expected 'Updated name', got '%s'", *req.Title)
 	}
 	if req.TargetDate != nil {
 		t.Error("expected nil target date")
@@ -187,11 +195,12 @@ func TestProjectLinkWithID(t *testing.T) {
 	}
 }
 
-func TestRoadmapItemWithID(t *testing.T) {
-	item := RoadmapItem{
+func TestMilestoneWithID(t *testing.T) {
+	item := Milestone{
 		ID:        7,
-		Name:      "Beta",
-		Completed: false,
+		Title:     "Beta",
+		Category:  "feature",
+		Status:    "planned",
 		SortOrder: 1,
 	}
 

--- a/internal/soon-cms/http.go
+++ b/internal/soon-cms/http.go
@@ -126,14 +126,23 @@ func (c CMS) DeleteLinkHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (c CMS) CreateRoadmapHandler(w http.ResponseWriter, r *http.Request) {
-	var req CreateRoadmapRequest
+func (c CMS) ListMilestonesHandler(w http.ResponseWriter, r *http.Request) {
+	milestones, err := c.getMilestones(r.PathValue("service"))
+	if err != nil {
+		jsonError(w, err)
+		return
+	}
+	jsonResponse(w, http.StatusOK, milestones)
+}
+
+func (c CMS) CreateMilestoneHandler(w http.ResponseWriter, r *http.Request) {
+	var req CreateMilestoneRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, err)
 		return
 	}
 
-	item, err := c.createRoadmapItem(r.PathValue("service"), req)
+	item, err := c.createMilestone(r.PathValue("service"), req)
 	if err != nil {
 		jsonError(w, err)
 		return
@@ -141,20 +150,20 @@ func (c CMS) CreateRoadmapHandler(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, http.StatusCreated, item)
 }
 
-func (c CMS) UpdateRoadmapHandler(w http.ResponseWriter, r *http.Request) {
+func (c CMS) UpdateMilestoneHandler(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.Atoi(r.PathValue("id"))
 	if err != nil {
 		jsonError(w, err)
 		return
 	}
 
-	var req UpdateRoadmapRequest
+	var req UpdateMilestoneRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, err)
 		return
 	}
 
-	item, err := c.updateRoadmapItem(id, req)
+	item, err := c.updateMilestone(id, req)
 	if err != nil {
 		jsonError(w, err)
 		return
@@ -162,77 +171,14 @@ func (c CMS) UpdateRoadmapHandler(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, http.StatusOK, item)
 }
 
-func (c CMS) DeleteRoadmapHandler(w http.ResponseWriter, r *http.Request) {
+func (c CMS) DeleteMilestoneHandler(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.Atoi(r.PathValue("id"))
 	if err != nil {
 		jsonError(w, err)
 		return
 	}
 
-	if err := c.deleteRoadmapItem(id); err != nil {
-		jsonError(w, err)
-		return
-	}
-	w.WriteHeader(http.StatusNoContent)
-}
-
-func (c CMS) ListTasksHandler(w http.ResponseWriter, r *http.Request) {
-	tasks, err := c.getLaunchTasks(r.PathValue("service"))
-	if err != nil {
-		jsonError(w, err)
-		return
-	}
-	jsonResponse(w, http.StatusOK, tasks)
-}
-
-func (c CMS) CreateTaskHandler(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		Completed bool `json:"completed"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		jsonError(w, err)
-		return
-	}
-
-	task, err := c.createLaunchTask(r.PathValue("service"), req.Completed)
-	if err != nil {
-		jsonError(w, err)
-		return
-	}
-	jsonResponse(w, http.StatusCreated, task)
-}
-
-func (c CMS) UpdateTaskHandler(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.Atoi(r.PathValue("id"))
-	if err != nil {
-		jsonError(w, err)
-		return
-	}
-
-	var req struct {
-		Completed bool `json:"completed"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		jsonError(w, err)
-		return
-	}
-
-	task, err := c.updateLaunchTask(id, req.Completed)
-	if err != nil {
-		jsonError(w, err)
-		return
-	}
-	jsonResponse(w, http.StatusOK, task)
-}
-
-func (c CMS) DeleteTaskHandler(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.Atoi(r.PathValue("id"))
-	if err != nil {
-		jsonError(w, err)
-		return
-	}
-
-	if err := c.deleteLaunchTask(id); err != nil {
+	if err := c.deleteMilestone(id); err != nil {
 		jsonError(w, err)
 		return
 	}

--- a/migrations/0005_unify_project_milestones.down.sql
+++ b/migrations/0005_unify_project_milestones.down.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS project_roadmap (
+    id SERIAL PRIMARY KEY,
+    service_id INTEGER REFERENCES services(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    target_date DATE,
+    release_date DATE,
+    completed BOOLEAN DEFAULT false,
+    sort_order INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS launch_task (
+    launch_task_id SERIAL PRIMARY KEY,
+    service_id INTEGER REFERENCES services(id) ON DELETE CASCADE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    completed BOOLEAN DEFAULT false,
+    task TEXT
+);
+
+INSERT INTO project_roadmap (service_id, name, target_date, release_date, completed, sort_order)
+SELECT
+    service_id,
+    title,
+    target_date,
+    completed_date,
+    status = 'completed',
+    sort_order
+FROM project_milestones
+WHERE category <> 'other';
+
+INSERT INTO launch_task (service_id, created_at, completed, task)
+SELECT
+    service_id,
+    created_at,
+    status = 'completed',
+    title
+FROM project_milestones
+WHERE category = 'other';
+
+DROP TABLE IF EXISTS project_milestones;

--- a/migrations/0005_unify_project_milestones.up.sql
+++ b/migrations/0005_unify_project_milestones.up.sql
@@ -1,0 +1,82 @@
+CREATE TABLE IF NOT EXISTS project_milestones (
+    id SERIAL PRIMARY KEY,
+    service_id INTEGER REFERENCES services(id) ON DELETE CASCADE,
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    category VARCHAR(50) NOT NULL DEFAULT 'feature',
+    status VARCHAR(50) NOT NULL DEFAULT 'planned',
+    target_date DATE,
+    completed_date DATE,
+    sort_order INTEGER DEFAULT 0,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+INSERT INTO project_milestones (
+    service_id,
+    title,
+    description,
+    category,
+    status,
+    target_date,
+    completed_date,
+    sort_order,
+    created_at,
+    updated_at
+)
+SELECT
+    service_id,
+    name,
+    NULL,
+    CASE WHEN release_date IS NOT NULL THEN 'release' ELSE 'feature' END,
+    CASE WHEN completed THEN 'completed' ELSE 'planned' END,
+    target_date,
+    release_date,
+    sort_order,
+    NOW(),
+    NOW()
+FROM project_roadmap
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM project_milestones pm
+    WHERE pm.service_id = project_roadmap.service_id
+      AND pm.title = project_roadmap.name
+      AND COALESCE(pm.target_date, DATE '1900-01-01') = COALESCE(project_roadmap.target_date, DATE '1900-01-01')
+      AND pm.sort_order = project_roadmap.sort_order
+);
+
+INSERT INTO project_milestones (
+    service_id,
+    title,
+    description,
+    category,
+    status,
+    target_date,
+    completed_date,
+    sort_order,
+    created_at,
+    updated_at
+)
+SELECT
+    service_id,
+    COALESCE(NULLIF(task, ''), 'Launch task #' || launch_task_id),
+    NULL,
+    'other',
+    CASE WHEN completed THEN 'completed' ELSE 'planned' END,
+    NULL,
+    NULL,
+    COALESCE(launch_task_id, 0),
+    created_at,
+    NOW()
+FROM launch_task
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM project_milestones pm
+    WHERE pm.service_id = launch_task.service_id
+      AND pm.title = COALESCE(NULLIF(launch_task.task, ''), 'Launch task #' || launch_task.launch_task_id)
+      AND pm.category = 'other'
+      AND pm.sort_order = COALESCE(launch_task.launch_task_id, 0)
+);
+
+DROP TABLE IF EXISTS project_roadmap;
+DROP TABLE IF EXISTS launch_task;


### PR DESCRIPTION
## Summary
- replace separate roadmap/task models with unified `project_milestones`
- add migration to move existing roadmap/task data into the new table
- expose milestone CRUD endpoints and compute progress from milestone status
- add test coverage for milestone progress calculation and migration versioning

## Verification
- `GOCACHE=/tmp/chewedfeed-go-build go test ./...`