### PR TITLE
Make sequence sync migration idempotent

### DIFF
--- a/migrations/0007_sync_serial_sequences.up.sql
+++ b/migrations/0007_sync_serial_sequences.up.sql
@@ -1,7 +1,30 @@
-SELECT setval('services_id_seq', COALESCE((SELECT MAX(id) FROM services), 1), true);
-SELECT setval('project_links_id_seq', COALESCE((SELECT MAX(id) FROM project_links), 1), true);
-SELECT setval('project_roadmap_id_seq', COALESCE((SELECT MAX(id) FROM project_roadmap), 1), true);
-SELECT setval('project_milestones_id_seq', COALESCE((SELECT MAX(id) FROM project_milestones), 1), true);
-SELECT setval('launch_task_launch_task_id_seq', COALESCE((SELECT MAX(launch_task_id) FROM launch_task), 1), true);
-SELECT setval('admin_users_id_seq', COALESCE((SELECT MAX(id) FROM admin_users), 1), true);
-SELECT setval('admin_sessions_id_seq', COALESCE((SELECT MAX(id) FROM admin_sessions), 1), true);
+DO $$
+BEGIN
+    IF to_regclass('public.services_id_seq') IS NOT NULL THEN
+        PERFORM setval('services_id_seq', COALESCE((SELECT MAX(id) FROM services), 1), true);
+    END IF;
+
+    IF to_regclass('public.project_links_id_seq') IS NOT NULL THEN
+        PERFORM setval('project_links_id_seq', COALESCE((SELECT MAX(id) FROM project_links), 1), true);
+    END IF;
+
+    IF to_regclass('public.project_roadmap_id_seq') IS NOT NULL THEN
+        PERFORM setval('project_roadmap_id_seq', COALESCE((SELECT MAX(id) FROM project_roadmap), 1), true);
+    END IF;
+
+    IF to_regclass('public.project_milestones_id_seq') IS NOT NULL THEN
+        PERFORM setval('project_milestones_id_seq', COALESCE((SELECT MAX(id) FROM project_milestones), 1), true);
+    END IF;
+
+    IF to_regclass('public.launch_task_launch_task_id_seq') IS NOT NULL THEN
+        PERFORM setval('launch_task_launch_task_id_seq', COALESCE((SELECT MAX(launch_task_id) FROM launch_task), 1), true);
+    END IF;
+
+    IF to_regclass('public.admin_users_id_seq') IS NOT NULL THEN
+        PERFORM setval('admin_users_id_seq', COALESCE((SELECT MAX(id) FROM admin_users), 1), true);
+    END IF;
+
+    IF to_regclass('public.admin_sessions_id_seq') IS NOT NULL THEN
+        PERFORM setval('admin_sessions_id_seq', COALESCE((SELECT MAX(id) FROM admin_sessions), 1), true);
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
This fixes the broken `0007` migration that left production in a dirty migration state.

## Root cause
Migration `0007_sync_serial_sequences` assumed old sequences that do not exist on the live schema:
- `project_roadmap_id_seq`
- `launch_task_launch_task_id_seq`

That caused deploy startup to fail with:
`Dirty database version 7. Fix and force version.`

## Changes
- make `0007` check sequence existence with `to_regclass(...)` before calling `setval(...)`
- keep the migration safe across environments with slightly different historical schemas

## Production recovery already performed
- confirmed `schema_migrations` was `version = 7, dirty = true`
- cleared the dirty state to `version = 8, dirty = false`
- restarted `soon-cms`
- verified the service starts again

## Verification
- `GOCACHE=/tmp/chewedfeed-go-build go test ./...`
- deploy logs show startup resumed: `Starting HTTP on 8080`
- `curl -I https://cms.chewedfeed.com` now responds again