### PR TITLE
Handle null service progress values

### DIFF
--- a/internal/soon-cms/cms.go
+++ b/internal/soon-cms/cms.go
@@ -140,7 +140,7 @@ func (c CMS) getServices() ([]Service, error) {
 		}
 	}()
 
-	rows, err := db.Query(c.CTX, "SELECT id, name, search_name, description, status, launch_year, launch_month, launch_day, url, progress, icon, full_description, uptime, live FROM services WHERE started = true")
+	rows, err := db.Query(c.CTX, "SELECT id, name, search_name, description, status, launch_year, launch_month, launch_day, url, COALESCE(progress, 0), icon, full_description, uptime, live FROM services WHERE started = true")
 	if err != nil {
 		return nil, logs.Error(err)
 	}
@@ -193,7 +193,7 @@ func (c CMS) getService(name string) (Service, error) {
 		}
 	}()
 
-	if err := db.QueryRow(c.CTX, "SELECT id, name, search_name, description, status, launch_year, launch_month, launch_day, url, progress, icon, full_description, uptime, live FROM services WHERE search_name = $1", name).Scan(
+	if err := db.QueryRow(c.CTX, "SELECT id, name, search_name, description, status, launch_year, launch_month, launch_day, url, COALESCE(progress, 0), icon, full_description, uptime, live FROM services WHERE search_name = $1", name).Scan(
 		&service.ID,
 		&service.Name,
 		&service.SearchName,

--- a/migrations/0009_backfill_service_progress.down.sql
+++ b/migrations/0009_backfill_service_progress.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE services
+    ALTER COLUMN progress DROP DEFAULT;

--- a/migrations/0009_backfill_service_progress.up.sql
+++ b/migrations/0009_backfill_service_progress.up.sql
@@ -1,0 +1,6 @@
+UPDATE services
+SET progress = 0
+WHERE progress IS NULL;
+
+ALTER TABLE services
+    ALTER COLUMN progress SET DEFAULT 0;


### PR DESCRIPTION
## Summary
This fixes the production `/services` 500 caused by legacy `NULL` values in `services.progress`.

## Root cause
The live database had at least one `services` row with `progress = NULL`. The CMS code scanned `progress` directly into an `int`, which caused requests to fail with:

`cannot scan NULL into *int`

## Changes
- read `progress` with `COALESCE(progress, 0)` in service queries
- add a migration to backfill `NULL` progress values to `0`
- set the `services.progress` default to `0`

## Production recovery already performed
- updated live `services` rows with `NULL progress` to `0`
- set the live `services.progress` default to `0`
- verified `/services` returns `200` again

## Verification
- `GOCACHE=/tmp/chewedfeed-go-build go test ./...`
- `curl -I https://cms.chewedfeed.com/services` returned `HTTP/2 200`